### PR TITLE
Option that forces the date format to be recognised read dd/mm/yy.

### DIFF
--- a/project.py
+++ b/project.py
@@ -40,7 +40,7 @@ def get_photo_info(date,reg):
 def main():
 	#load data, set the date column to datetime
 	data = pd.read_csv("Logbook.csv")
-	data['Date'] = pd.to_datetime(data['Date'])
+	data['Date'] = pd.to_datetime(data['Date'], dayfirst=True)
 
 	#initalise variable to check for repetition
 	reg_prev = None
@@ -65,4 +65,3 @@ def main():
 
 if __name__ == '__main__':
 	main()
-	


### PR DESCRIPTION
Ran into a couple of false hits and realised the script had transposed the day and month in cases where the date is 12 or less, but correctly decoded it when the date was greater than 12. 
This forces it to read the date first, but obviously then restricts the script if the logbook is in mm/dd/yy format.